### PR TITLE
Preserve the link token and fix the password handling.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ test-php-unit:
 
 .PHONY: test-php-unit-dbg
 test-php-unit-dbg:
-	$(PHPUNITDBG) --configuration ./phpunit.xml --testsuite unit
+	$(PHPUNITDBG) --configuration ./phpunit.xml --testsuite unit --coverage-clover ./tests/output/clover-unit.xml
 
 .PHONY: test-php-integration
 test-php-integration:
@@ -116,7 +116,7 @@ test-php-integration:
 
 .PHONY: test-php-integration-dbg
 test-php-integration-dbg:
-	$(PHPUNITDBG) --configuration ./phpunit.xml --testsuite integration
+	$(PHPUNITDBG) --configuration ./phpunit.xml --testsuite integration --coverage-clover ./tests/output/clover-integration.xml
 
 .PHONY: test-acceptance-cli
 test-acceptance-cli:

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -58,7 +58,7 @@ Note: If the user is stored in the database you need to manually reset his passw
 - Share's state will be always "accepted" regardless of the state in the old server.
 - Remote shares from both directions need to be manually accepted.
 - Federated shares from other servers are not migrated.
-- Password protected link-shares are not imported correctly, user needs to reset the password.
+- Password protected link-shares are only working with the same password on the new server if the `passwordsalt` key from config.php is copied from the old server to the new one.
 - Group shares require the group to be present on the target-system or else the share will be ignored silently.
 - If link-shares require a password on the new server but do so on the old the import process will crash.
 

--- a/lib/Exporter/MetadataExtractor/SharesExtractor.php
+++ b/lib/Exporter/MetadataExtractor/SharesExtractor.php
@@ -153,7 +153,8 @@ class SharesExtractor {
 					->setOwner($share->getShareOwner())
 					->setSharedBy($share->getSharedBy())
 					->setPermissions($share->getPermissions())
-					->setName($share->getName());
+					->setName($share->getName())
+					->setToken($share->getToken());
 
 				$expiration = $share->getExpirationDate();
 				if ($expiration) {

--- a/lib/Importer/MetadataImporter/ShareImporter.php
+++ b/lib/Importer/MetadataImporter/ShareImporter.php
@@ -229,6 +229,7 @@ class ShareImporter {
 		$node = $userFolder->get($shareModel->getPath());  // this might throw an OCP\Files\NotFoundException
 
 		$share = $this->shareManager->newShare();
+		$share->setShouldHashPassword(false);
 		$share->setNode($node)
 			->setShareType(ShareConstants::SHARE_TYPE_LINK)
 			->setPermissions($shareModel->getPermissions())
@@ -243,7 +244,10 @@ class ShareImporter {
 			$share->setExpirationDate($datetime);
 		}
 
-		$this->shareManager->createShare($share);
+		$share = $this->shareManager->createShare($share);
+		// CreateShare sets a new token, so update the share after creating.
+		$share->setToken($shareModel->getToken());
+		$this->shareManager->updateShare($share);
 	}
 
 	/**

--- a/lib/Model/User/Share.php
+++ b/lib/Model/User/Share.php
@@ -46,6 +46,8 @@ class Share {
 	private $password;
 	/** @var string|null */
 	private $name;
+	/** @var string|null */
+	private $token;
 
 	/**
 	 * @return string
@@ -189,6 +191,23 @@ class Share {
 	 */
 	public function setName($name): Share {
 		$this->name = $name;
+		return $this;
+	}
+
+	/**
+	 * @return string|null the token of the share link or null if the share isn't
+	 * a share link
+	 */
+	public function getToken() {
+		return $this->token;
+	}
+
+	/**
+	 * @param string|null $token the token of the share link
+	 * @return Share
+	 */
+	public function setToken($token): Share {
+		$this->token = $token;
 		return $this;
 	}
 }

--- a/tests/unit/Exporter/MetadataExtractor/SharesExtractorTest.php
+++ b/tests/unit/Exporter/MetadataExtractor/SharesExtractorTest.php
@@ -63,7 +63,7 @@ class SharesExtractorTest extends TestCase {
 		return $share;
 	}
 
-	private function getFakeLinkShare(string $path, string $owner, string $sharedBy, string $permissions, string $name, $expiration, $password) {
+	private function getFakeLinkShare(string $path, string $owner, string $sharedBy, string $permissions, string $name, string $token, $expiration, $password) {
 		$node = $this->createMock(Node::class);
 		$node->method('getPath')->willReturn($path);
 
@@ -73,6 +73,7 @@ class SharesExtractorTest extends TestCase {
 		$share->method('getSharedBy')->willReturn($sharedBy);
 		$share->method('getPermissions')->willReturn($permissions);
 		$share->method('getName')->willReturn($name);
+		$share->method('getToken')->willReturn($token);
 		if ($expiration) {
 			$share->method('getExpirationDate')->willReturn($expiration);
 		}
@@ -87,7 +88,7 @@ class SharesExtractorTest extends TestCase {
 		$userShare1 = $this->getFakeShare('/usertest/files/path/to/file', 'usertest', 'usertest', 'usertest2', 1);
 		$userShare2 = $this->getFakeShare('/usertest/files/path/to/file', 'usertest', 'initiator', 'usertest2', 1);
 		$groupShare1 = $this->getFakeShare('/usertest/files/path/to/file', 'usertest', 'initiator', 'group', 31);
-		$linkShare1 = $this->getFakeLinkShare('/usertest/files/path/to/file', 'usertest', 'initiator', 31, 'my link name', null, null);
+		$linkShare1 = $this->getFakeLinkShare('/usertest/files/path/to/file', 'usertest', 'initiator', 31, 'my link name', '#token', null, null);
 		$remoteShare1 = $this->getFakeShare('/usertest/files/path/to/file', 'usertest', 'initiator', 'user@remote', 1);
 
 		$this->manager->method('getSharesBy')
@@ -142,6 +143,7 @@ class SharesExtractorTest extends TestCase {
 				->setOwner('usertest')
 				->setSharedBy('initiator')
 				->setPermissions(31)
+				->setToken('#token')
 				->setName('my link name'),
 			(new Share())
 				->setPath('/path/to/file')
@@ -161,6 +163,7 @@ class SharesExtractorTest extends TestCase {
 			$this->assertEquals($expectedShareModel->getSharedBy(), $realModels[$key]->getSharedBy());
 			$this->assertEquals($expectedShareModel->getSharedWith(), $realModels[$key]->getSharedWith());
 			$this->assertEquals($expectedShareModel->getPermissions(), $realModels[$key]->getPermissions());
+			$this->assertEquals($expectedShareModel->getToken(), $realModels[$key]->getToken());
 			$this->assertEquals($expectedShareModel->getExpirationDate(), $realModels[$key]->getExpirationDate());
 			$this->assertEquals($expectedShareModel->getPassword(), $realModels[$key]->getPassword());
 			$this->assertEquals($expectedShareModel->getName(), $realModels[$key]->getName());
@@ -188,10 +191,10 @@ class SharesExtractorTest extends TestCase {
 		$testDateTime = new \DateTime();
 		$testDateTime->setTimestamp(12345678);
 
-		$linkShare1 = $this->getFakeLinkShare('/usertest/files/path/to/file', 'usertest', 'initiator', 31, 'my link name', null, null);
-		$linkShare2 = $this->getFakeLinkShare('/usertest/files/path/to/file', 'usertest', 'initiator', 31, 'my link name', $testDateTime, null);
-		$linkShare3 = $this->getFakeLinkShare('/usertest/files/path/to/file', 'usertest', 'initiator', 31, 'my link name', null, 'hashed#Password');
-		$linkShare4 = $this->getFakeLinkShare('/usertest/files/path/to/file', 'usertest', 'initiator', 31, 'my link name', $testDateTime, 'hashed#Password');
+		$linkShare1 = $this->getFakeLinkShare('/usertest/files/path/to/file', 'usertest', 'initiator', 31, 'my link name', '#token-1', null, null);
+		$linkShare2 = $this->getFakeLinkShare('/usertest/files/path/to/file', 'usertest', 'initiator', 31, 'my link name', '#token-2', $testDateTime, null);
+		$linkShare3 = $this->getFakeLinkShare('/usertest/files/path/to/file', 'usertest', 'initiator', 31, 'my link name', '#token-3', null, 'hashed#Password');
+		$linkShare4 = $this->getFakeLinkShare('/usertest/files/path/to/file', 'usertest', 'initiator', 31, 'my link name', '#token-4', $testDateTime, 'hashed#Password');
 
 		$this->manager->method('getSharesBy')
 			->will($this->returnValueMap([
@@ -224,6 +227,7 @@ class SharesExtractorTest extends TestCase {
 				->setOwner('usertest')
 				->setSharedBy('initiator')
 				->setPermissions(31)
+				->setToken('#token-1')
 				->setName('my link name'),
 			(new Share())
 				->setPath('/path/to/file')
@@ -231,6 +235,7 @@ class SharesExtractorTest extends TestCase {
 				->setOwner('usertest')
 				->setSharedBy('initiator')
 				->setPermissions(31)
+				->setToken('#token-2')
 				->setName('my link name')
 				->setExpirationDate(12345678),
 			(new Share())
@@ -239,6 +244,7 @@ class SharesExtractorTest extends TestCase {
 				->setOwner('usertest')
 				->setSharedBy('initiator')
 				->setPermissions(31)
+				->setToken('#token-3')
 				->setName('my link name')
 				->setPassword('hashed#Password'),
 			(new Share())
@@ -247,6 +253,7 @@ class SharesExtractorTest extends TestCase {
 				->setOwner('usertest')
 				->setSharedBy('initiator')
 				->setPermissions(31)
+				->setToken('#token-4')
 				->setName('my link name')
 				->setExpirationDate(12345678)
 				->setPassword('hashed#Password'),
@@ -261,6 +268,7 @@ class SharesExtractorTest extends TestCase {
 			$this->assertEquals($expectedShareModel->getSharedBy(), $realModels[$key]->getSharedBy());
 			$this->assertEquals($expectedShareModel->getSharedWith(), $realModels[$key]->getSharedWith());
 			$this->assertEquals($expectedShareModel->getPermissions(), $realModels[$key]->getPermissions());
+			$this->assertEquals($expectedShareModel->getToken(), $realModels[$key]->getToken());
 			$this->assertEquals($expectedShareModel->getExpirationDate(), $realModels[$key]->getExpirationDate());
 			$this->assertEquals($expectedShareModel->getPassword(), $realModels[$key]->getPassword());
 			$this->assertEquals($expectedShareModel->getName(), $realModels[$key]->getName());

--- a/tests/unit/Importer/MetadataImporter/ShareImporterTest.php
+++ b/tests/unit/Importer/MetadataImporter/ShareImporterTest.php
@@ -97,6 +97,7 @@ class ShareImporterTest extends TestCase {
 			$share->getShareOwner() === $shareData['owner'] &&
 			$share->getName() === $shareData['name'] &&
 			$share->getPassword() === $shareData['password'] &&
+			$share->getToken() === $shareData['token'] &&
 			($share->getExpirationDate() === $shareData['expiration'] || $isSameDate);
 	}
 
@@ -362,6 +363,7 @@ class ShareImporterTest extends TestCase {
 			->setOwner('usertest')
 			->setSharedBy('usertest')
 			->setName('my link name')
+			->setToken('secret')
 			->setPermissions(1);
 
 		$this->setupRootFolderForTests();
@@ -381,6 +383,25 @@ class ShareImporterTest extends TestCase {
 					'owner' => 'usertest',
 					'name' => 'my link name',
 					'password' => null,
+					'token' => null,
+					'expiration' => null,
+				];
+				return $this->isSameLinkShare($share, $shareData);
+			}))
+			->willReturnArgument(0);
+
+		$this->shareManager->expects($this->once())
+			->method('updateShare')
+			->with($this->callback(function ($share) {
+				$shareData = [
+					'path' => '/usertest/files/path/to/file',
+					'type' => ShareConstants::SHARE_TYPE_LINK,
+					'permissions' => 1,
+					'by' => 'usertest',  // sharedBy overwritten for now
+					'owner' => 'usertest',
+					'name' => 'my link name',
+					'password' => null,
+					'token' => 'secret',
 					'expiration' => null,
 				];
 				return $this->isSameLinkShare($share, $shareData);
@@ -397,6 +418,7 @@ class ShareImporterTest extends TestCase {
 			->setSharedBy('usertest')
 			->setName('my link name')
 			->setPassword('aWeSoMe')
+			->setToken('secret')
 			->setPermissions(1);
 
 		$this->setupRootFolderForTests();
@@ -416,6 +438,25 @@ class ShareImporterTest extends TestCase {
 					'owner' => 'usertest',
 					'name' => 'my link name',
 					'password' => 'aWeSoMe',  // password might be hashed inside the createShare method, but not outside
+					'token' => null,
+					'expiration' => null,
+				];
+				return $this->isSameLinkShare($share, $shareData);
+			}))
+			->willReturnArgument(0);
+
+		$this->shareManager->expects($this->once())
+			->method('updateShare')
+			->with($this->callback(function ($share) {
+				$shareData = [
+					'path' => '/usertest/files/path/to/file',
+					'type' => ShareConstants::SHARE_TYPE_LINK,
+					'permissions' => 1,
+					'by' => 'usertest',  // sharedBy overwritten for now
+					'owner' => 'usertest',
+					'name' => 'my link name',
+					'password' => 'aWeSoMe',
+					'token' => 'secret',
 					'expiration' => null,
 				];
 				return $this->isSameLinkShare($share, $shareData);
@@ -434,6 +475,7 @@ class ShareImporterTest extends TestCase {
 			->setSharedBy('usertest')
 			->setName('my link name')
 			->setExpirationDate($expiration->getTimestamp())
+			->setToken('secret')
 			->setPermissions(1);
 
 		$this->setupRootFolderForTests();
@@ -452,7 +494,26 @@ class ShareImporterTest extends TestCase {
 					'by' => 'usertest',  // sharedBy overwritten for now
 					'owner' => 'usertest',
 					'name' => 'my link name',
+					'token' => null,
 					'password' => null,
+					'expiration' => $expiration,
+				];
+				return $this->isSameLinkShare($share, $shareData);
+			}))
+			->willReturnArgument(0);
+
+		$this->shareManager->expects($this->once())
+			->method('updateShare')
+			->with($this->callback(function ($share) use ($expiration) {
+				$shareData = [
+					'path' => '/usertest/files/path/to/file',
+					'type' => ShareConstants::SHARE_TYPE_LINK,
+					'permissions' => 1,
+					'by' => 'usertest',  // sharedBy overwritten for now
+					'owner' => 'usertest',
+					'name' => 'my link name',
+					'password' => null,
+					'token' => 'secret',
 					'expiration' => $expiration,
 				];
 				return $this->isSameLinkShare($share, $shareData);
@@ -471,6 +532,7 @@ class ShareImporterTest extends TestCase {
 			->setSharedBy('usertest')
 			->setName('my link name')
 			->setPassword('aWeSoMe')
+			->setToken('secret')
 			->setExpirationDate($expiration->getTimestamp())
 			->setPermissions(1);
 
@@ -491,6 +553,25 @@ class ShareImporterTest extends TestCase {
 					'owner' => 'usertest',
 					'name' => 'my link name',
 					'password' => 'aWeSoMe',
+					'token' => null,
+					'expiration' => $expiration,
+				];
+				return $this->isSameLinkShare($share, $shareData);
+			}))
+			->willReturnArgument(0);
+
+		$this->shareManager->expects($this->once())
+			->method('updateShare')
+			->with($this->callback(function ($share) use ($expiration) {
+				$shareData = [
+					'path' => '/usertest/files/path/to/file',
+					'type' => ShareConstants::SHARE_TYPE_LINK,
+					'permissions' => 1,
+					'by' => 'usertest',  // sharedBy overwritten for now
+					'owner' => 'usertest',
+					'name' => 'my link name',
+					'password' => 'aWeSoMe',
+					'token' => 'secret',
 					'expiration' => $expiration,
 				];
 				return $this->isSameLinkShare($share, $shareData);


### PR DESCRIPTION
## Description
Fix the importing of passwords for public links, copy over the tokens.

## Motivation and Context
Use Case: Clone an instance. Public Links should be available with the same tokens and passwords.
This requires `passwordsalt` to be copied over from config.php

## How Has This Been Tested?
manually

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly. (manual.md)
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

