### PR TITLE
Allow to export metadata-only

### DIFF
--- a/lib/Command/ExportUser.php
+++ b/lib/Command/ExportUser.php
@@ -26,6 +26,7 @@ use OCA\DataExporter\Exporter;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ExportUser extends Command {
@@ -42,14 +43,16 @@ class ExportUser extends Command {
 		$this->setName('instance:export:user')
 			->setDescription('Exports a single user')
 			->addArgument('userId', InputArgument::REQUIRED, 'User to export')
-			->addArgument('exportDirectory', InputArgument::REQUIRED, 'Path to the directory to export data to');
+			->addArgument('exportDirectory', InputArgument::REQUIRED, 'Path to the directory to export data to')
+			->addOption("no-files", "m", InputOption::VALUE_NONE, 'Skip exporting files (export metadata only)');
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
 		try {
 			$this->exporter->export(
 				$input->getArgument('userId'),
-				$input->getArgument('exportDirectory')
+				$input->getArgument('exportDirectory'),
+				!$input->getOption('no-files')
 			);
 		} catch (\Exception $e) {
 			$output->writeln("<error>{$e->getMessage()}</error>");

--- a/lib/Exporter.php
+++ b/lib/Exporter.php
@@ -47,6 +47,7 @@ class Exporter {
 	/**
 	 * @param string $uid
 	 * @param string $exportDirectoryPath
+	 * @param bool $exportFiles
 	 *
 	 * @throws \OCP\Files\NotFoundException
 	 * @throws \OCP\Files\NotPermittedException
@@ -54,7 +55,7 @@ class Exporter {
 	 *
 	 * @return void
 	 */
-	public function export($uid, $exportDirectoryPath) {
+	public function export($uid, $exportDirectoryPath, $exportFiles = true) {
 		$exportPath = "$exportDirectoryPath/$uid";
 		$metaData = $this->metadataExtractor->extract($uid, $exportPath);
 		$this->filesystem->dumpFile(
@@ -62,7 +63,9 @@ class Exporter {
 			$this->serializer->serialize($metaData)
 		);
 
-		$filesPath = \ltrim("$exportPath/files");
-		$this->filesExtractor->export($uid, $filesPath);
+		if ($exportFiles) {
+			$filesPath = \ltrim("$exportPath/files");
+			$this->filesExtractor->export($uid, $filesPath);
+		}
 	}
 }


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Export metadata only without writing files

## Related Issue
Closes #97

## Motivation and Context
As with bigger migrations there is simply no room to copy the data this PR adds an option where only the metadata is exported and the data-directory of source->target system can be moved/mounted manually
