### PR TITLE
Don't copy whole file in to memory during export

### DIFF
--- a/lib/Extractor/FilesExtractor.php
+++ b/lib/Extractor/FilesExtractor.php
@@ -56,7 +56,24 @@ class FilesExtractor {
 			$path = "${exportPath}${relativeFileCachePath}";
 
 			if ($node instanceof File) {
-				$this->filesystem->dumpFile($path, $node->getContent());
+				@\mkdir(\pathinfo($path, PATHINFO_DIRNAME), 0777, true);
+
+				$src = $node->fopen('rb');
+				if (!\is_resource($src)) {
+					throw new \RuntimeException("Couldn't read $nodePath from owncloud");
+				}
+
+				$dst = \fopen($path, 'wb+');
+				if (!\is_resource($src)) {
+					\fclose($src);
+					throw new \RuntimeException("Couldn't create $path in export");
+				}
+
+				\stream_copy_to_stream($src, $dst);
+
+				\fclose($src);
+				\fclose($dst);
+
 				continue;
 			}
 

--- a/lib/Extractor/FilesExtractor.php
+++ b/lib/Extractor/FilesExtractor.php
@@ -64,7 +64,7 @@ class FilesExtractor {
 				}
 
 				$dst = \fopen($path, 'wb+');
-				if (!\is_resource($src)) {
+				if (!\is_resource($dst)) {
 					\fclose($src);
 					throw new \RuntimeException("Couldn't create $path in export");
 				}

--- a/lib/Importer/FilesImporter.php
+++ b/lib/Importer/FilesImporter.php
@@ -105,7 +105,7 @@ class FilesImporter {
 					}
 
 					$dst = $file->fopen("wb+");
-					if (!\is_resource($src)) {
+					if (!\is_resource($dst)) {
 						\fclose($src);
 						throw new \RuntimeException("Couldn't open node for writing for file $fileCachePath");
 					}

--- a/lib/Importer/FilesImporter.php
+++ b/lib/Importer/FilesImporter.php
@@ -98,6 +98,22 @@ class FilesImporter {
 
 				if ($fileMetadata->getType() === File::TYPE_FILE) {
 					$file = $userFolder->newFile($fileCachePath);
+
+					$src = \fopen($pathToFileInExport, "rb+");
+					if (!\is_resource($src)) {
+						throw new \RuntimeException("Couldn't read file in export $pathToFileInExport");
+					}
+
+					$dst = $file->fopen("wb+");
+					if (!\is_resource($src)) {
+						\fclose($src);
+						throw new \RuntimeException("Couldn't open node for writing for file $fileCachePath");
+					}
+
+					\stream_copy_to_stream($src, $dst);
+					\fclose($src);
+					\fclose($dst);
+
 					$file->putContent(\file_get_contents($pathToFileInExport));
 					$file->getStorage()->getCache()->update($file->getId(), [
 						'etag' => $fileMetadata->getETag(),

--- a/tests/unit/Importer/FilesImporterTest.php
+++ b/tests/unit/Importer/FilesImporterTest.php
@@ -123,6 +123,7 @@ class FilesImporterTest extends TestCase {
 		$mockFile1->method('getEtag')->willReturn('533c8d4b4c45b62e68cc09e810db7a23');
 		$mockFile1->method('getPermissions')->willReturn(27);
 		$mockFile1->method('getType')->willReturn(Node::TYPE_FILE);
+		$mockFile1->method('fopen')->willReturn(\fopen('php://memory', 'wb+'));
 		$storageFile = $this->createMock(Storage::class);
 		$cacheFile = $this->createMock(Cache::class);
 		// Test that the File Cache is updated for this file


### PR DESCRIPTION
The file was read in to memory during export. This lead to OOM with bigger files (e.g vm Images)

Close #28 

