### PR TITLE
Add php unit composer dependencies to Makefile

### DIFF
--- a/.drone.starlark
+++ b/.drone.starlark
@@ -1157,6 +1157,7 @@ def installCore(version, db, useBundledApp):
 		'settings': {
 			'version': version,
 			'core_path': '/var/www/owncloud/server',
+			'db_timeout': 120,
 			'db_type': dbType,
 			'db_name': database,
 			'db_host': host,

--- a/.drone.yml
+++ b/.drone.yml
@@ -46,6 +46,7 @@ steps:
     db_host: sqlite
     db_name: owncloud
     db_password: owncloud
+    db_timeout: 120
     db_type: sqlite
     db_username: owncloud
     exclude: apps/data_exporter
@@ -104,6 +105,7 @@ steps:
     db_host: sqlite
     db_name: owncloud
     db_password: owncloud
+    db_timeout: 120
     db_type: sqlite
     db_username: owncloud
     exclude: apps/data_exporter
@@ -143,6 +145,7 @@ steps:
     db_host: sqlite
     db_name: owncloud
     db_password: owncloud
+    db_timeout: 120
     db_type: sqlite
     db_username: owncloud
     exclude: apps/data_exporter
@@ -182,6 +185,7 @@ steps:
     db_host: sqlite
     db_name: owncloud
     db_password: owncloud
+    db_timeout: 120
     db_type: sqlite
     db_username: owncloud
     exclude: apps/data_exporter
@@ -221,6 +225,7 @@ steps:
     db_host: sqlite
     db_name: owncloud
     db_password: owncloud
+    db_timeout: 120
     db_type: sqlite
     db_username: owncloud
     exclude: apps/data_exporter
@@ -260,6 +265,7 @@ steps:
     db_host: sqlite
     db_name: owncloud
     db_password: owncloud
+    db_timeout: 120
     db_type: sqlite
     db_username: owncloud
     exclude: apps/data_exporter
@@ -335,6 +341,7 @@ steps:
     db_host: mariadb
     db_name: owncloud
     db_password: owncloud
+    db_timeout: 120
     db_type: mysql
     db_username: owncloud
     exclude: apps/data_exporter
@@ -420,6 +427,7 @@ steps:
     db_host: mysql
     db_name: owncloud
     db_password: owncloud
+    db_timeout: 120
     db_type: mysql
     db_username: owncloud
     exclude: apps/data_exporter
@@ -505,6 +513,7 @@ steps:
     db_host: mysql
     db_name: owncloud
     db_password: owncloud
+    db_timeout: 120
     db_type: mysql
     db_username: owncloud
     exclude: apps/data_exporter
@@ -590,6 +599,7 @@ steps:
     db_host: postgres
     db_name: owncloud
     db_password: owncloud
+    db_timeout: 120
     db_type: pgsql
     db_username: owncloud
     exclude: apps/data_exporter
@@ -674,6 +684,7 @@ steps:
     db_host: oracle
     db_name: XE
     db_password: oracle
+    db_timeout: 120
     db_type: oci
     db_username: system
     exclude: apps/data_exporter
@@ -759,6 +770,7 @@ steps:
     db_host: mysql
     db_name: owncloud
     db_password: owncloud
+    db_timeout: 120
     db_type: mysql
     db_username: owncloud
     exclude: apps/data_exporter
@@ -835,6 +847,7 @@ steps:
     db_host: mysql
     db_name: owncloud
     db_password: owncloud
+    db_timeout: 120
     db_type: mysql
     db_username: owncloud
     exclude: apps/data_exporter
@@ -911,6 +924,7 @@ steps:
     db_host: mysql
     db_name: owncloud
     db_password: owncloud
+    db_timeout: 120
     db_type: mysql
     db_username: owncloud
     exclude: apps/data_exporter
@@ -987,6 +1001,7 @@ steps:
     db_host: sqlite
     db_name: owncloud
     db_password: owncloud
+    db_timeout: 120
     db_type: sqlite
     db_username: owncloud
     exclude: apps/data_exporter
@@ -1062,6 +1077,7 @@ steps:
     db_host: mariadb
     db_name: owncloud
     db_password: owncloud
+    db_timeout: 120
     db_type: mysql
     db_username: owncloud
     exclude: apps/data_exporter
@@ -1147,6 +1163,7 @@ steps:
     db_host: mysql
     db_name: owncloud
     db_password: owncloud
+    db_timeout: 120
     db_type: mysql
     db_username: owncloud
     exclude: apps/data_exporter
@@ -1232,6 +1249,7 @@ steps:
     db_host: mysql
     db_name: owncloud
     db_password: owncloud
+    db_timeout: 120
     db_type: mysql
     db_username: owncloud
     exclude: apps/data_exporter
@@ -1317,6 +1335,7 @@ steps:
     db_host: postgres
     db_name: owncloud
     db_password: owncloud
+    db_timeout: 120
     db_type: pgsql
     db_username: owncloud
     exclude: apps/data_exporter
@@ -1401,6 +1420,7 @@ steps:
     db_host: oracle
     db_name: XE
     db_password: oracle
+    db_timeout: 120
     db_type: oci
     db_username: system
     exclude: apps/data_exporter
@@ -1486,6 +1506,7 @@ steps:
     db_host: mysql
     db_name: owncloud
     db_password: owncloud
+    db_timeout: 120
     db_type: mysql
     db_username: owncloud
     exclude: apps/data_exporter
@@ -1562,6 +1583,7 @@ steps:
     db_host: mysql
     db_name: owncloud
     db_password: owncloud
+    db_timeout: 120
     db_type: mysql
     db_username: owncloud
     exclude: apps/data_exporter
@@ -1638,6 +1660,7 @@ steps:
     db_host: mysql
     db_name: owncloud
     db_password: owncloud
+    db_timeout: 120
     db_type: mysql
     db_username: owncloud
     exclude: apps/data_exporter
@@ -1714,6 +1737,7 @@ steps:
     db_host: mariadb
     db_name: owncloud
     db_password: owncloud
+    db_timeout: 120
     db_type: mysql
     db_username: owncloud
     exclude: apps/data_exporter
@@ -1831,6 +1855,7 @@ steps:
     db_host: mysql
     db_name: owncloud
     db_password: owncloud
+    db_timeout: 120
     db_type: mysql
     db_username: owncloud
     exclude: apps/data_exporter
@@ -1948,6 +1973,7 @@ steps:
     db_host: mysql
     db_name: owncloud
     db_password: owncloud
+    db_timeout: 120
     db_type: mysql
     db_username: owncloud
     exclude: apps/data_exporter
@@ -2065,6 +2091,7 @@ steps:
     db_host: postgres
     db_name: owncloud
     db_password: owncloud
+    db_timeout: 120
     db_type: pgsql
     db_username: owncloud
     exclude: apps/data_exporter
@@ -2181,6 +2208,7 @@ steps:
     db_host: oracle
     db_name: XE
     db_password: oracle
+    db_timeout: 120
     db_type: oci
     db_username: system
     exclude: apps/data_exporter
@@ -2298,6 +2326,7 @@ steps:
     db_host: mariadb
     db_name: owncloud
     db_password: owncloud
+    db_timeout: 120
     db_type: mysql
     db_username: owncloud
     exclude: apps/data_exporter
@@ -2415,6 +2444,7 @@ steps:
     db_host: mysql
     db_name: owncloud
     db_password: owncloud
+    db_timeout: 120
     db_type: mysql
     db_username: owncloud
     exclude: apps/data_exporter
@@ -2532,6 +2562,7 @@ steps:
     db_host: mysql
     db_name: owncloud
     db_password: owncloud
+    db_timeout: 120
     db_type: mysql
     db_username: owncloud
     exclude: apps/data_exporter
@@ -2649,6 +2680,7 @@ steps:
     db_host: postgres
     db_name: owncloud
     db_password: owncloud
+    db_timeout: 120
     db_type: pgsql
     db_username: owncloud
     exclude: apps/data_exporter
@@ -2765,6 +2797,7 @@ steps:
     db_host: oracle
     db_name: XE
     db_password: oracle
+    db_timeout: 120
     db_type: oci
     db_username: system
     exclude: apps/data_exporter

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,12 @@ clean-composer-dev-deps:
 	rm -Rf vendor
 	rm -Rf vendor-bin/**/vendor vendor-bin/**/composer.lock
 
+composer.lock: composer.json
+	@echo composer.lock is not up to date.
+
+vendor: composer.lock
+	$(COMPOSER_BIN) install --no-dev
+
 vendor/bamarni/composer-bin-plugin: composer.lock
 	composer install
 
@@ -96,11 +102,11 @@ test-php-phan: vendor-bin/phan/vendor
 	$(PHAN) --config-file .phan/config.php --require-config-exists
 
 .PHONY: test-php-unit
-test-php-unit:
+test-php-unit: $(composer_deps) $(composer_dev_deps)
 	$(PHPUNIT) --configuration ./phpunit.xml --testsuite unit
 
 .PHONY: test-php-unit-dbg
-test-php-unit-dbg:
+test-php-unit-dbg: $(composer_deps) $(composer_dev_deps)
 	$(PHPUNITDBG) --configuration ./phpunit.xml --testsuite unit --coverage-clover ./tests/output/clover.xml
 
 .PHONY: test-php-integration


### PR DESCRIPTION
## Description
If I clone this repo and immediately `make test-php-unit` it dies. I first need to know to do `composer install` or some other `make` target that will install the composer dependencies.

Add the composer dependencies so that `make test-php-unit` will "just work"

(I noticed this when sorting out `Makefile` for the metrics app)

## How Has This Been Tested?
Local `make test-php-unit`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] tests only

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

