### PR TITLE
Export file-id's

### DIFF
--- a/lib/Command/ExportUser.php
+++ b/lib/Command/ExportUser.php
@@ -44,7 +44,8 @@ class ExportUser extends Command {
 			->setDescription('Exports a single user')
 			->addArgument('userId', InputArgument::REQUIRED, 'User to export')
 			->addArgument('exportDirectory', InputArgument::REQUIRED, 'Path to the directory to export data to')
-			->addOption("no-files", "m", InputOption::VALUE_NONE, 'Skip exporting files (export metadata only)');
+			->addOption('no-files', 'm', InputOption::VALUE_NONE, 'Skip exporting files (export metadata only)')
+			->addOption('with-file-ids', 'i', InputOption::VALUE_NONE, 'Export file-ids in file-metadata');
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
@@ -52,7 +53,8 @@ class ExportUser extends Command {
 			$this->exporter->export(
 				$input->getArgument('userId'),
 				$input->getArgument('exportDirectory'),
-				!$input->getOption('no-files')
+				!$input->getOption('no-files'),
+				$input->getOption('with-file-ids')
 			);
 		} catch (\Exception $e) {
 			$output->writeln("<error>{$e->getMessage()}</error>");

--- a/lib/Exporter.php
+++ b/lib/Exporter.php
@@ -56,9 +56,10 @@ class Exporter {
 	 *
 	 * @return void
 	 */
-	public function export($uid, $exportDirectoryPath, $exportFiles = true) {
+	public function export($uid, $exportDirectoryPath, $exportFiles = true, $exportFileIds = false) {
 		$exportPath = Path::join($exportDirectoryPath, $uid);
-		$metaData = $this->metadataExtractor->extract($uid, $exportPath);
+		$metaData = $this->metadataExtractor->extract($uid, $exportPath, $exportFileIds);
+
 		$this->filesystem->dumpFile(
 			Path::join($exportPath, '/user.json'),
 			$this->serializer->serialize($metaData)

--- a/lib/Extractor/MetadataExtractor.php
+++ b/lib/Extractor/MetadataExtractor.php
@@ -80,7 +80,7 @@ class MetadataExtractor {
 	 * @throws \Exception
 	 * @throws \RuntimeException if user can not be read
 	 */
-	public function extract($uid, $exportPath) {
+	public function extract($uid, $exportPath, $extractFileIds = true) {
 		$user = $this->userExtractor->extract($uid);
 		$user->setPreferences($this->preferencesExtractor->extract($uid));
 		$metadata = new Metadata();
@@ -88,7 +88,7 @@ class MetadataExtractor {
 			->setUser($user)
 			->setOriginServer($this->urlGenerator->getAbsoluteURL('/'));
 
-		$this->filesMetadataExtractor->extract($uid, $exportPath);
+		$this->filesMetadataExtractor->extract($uid, $exportPath, $extractFileIds);
 		$this->sharesExtractor->extract($uid, $exportPath);
 
 		return $metadata;

--- a/lib/Extractor/MetadataExtractor/FilesMetadataExtractor.php
+++ b/lib/Extractor/MetadataExtractor/FilesMetadataExtractor.php
@@ -51,13 +51,18 @@ class FilesMetadataExtractor {
 	/**
 	 * @param string $userId
 	 * @param string $exportPath
+	 * @param bool $extractFileIds
 	 *
 	 * @return void
 	 *
 	 * @throws NoUserException
 	 */
-	public function extract($userId, $exportPath) {
+	public function extract($userId, $exportPath, $extractFileIds = false) {
 		list($iterator, $baseFolder) = $this->iteratorFactory->getUserFolderRecursiveIterator($userId);
+		$ignoredAttributes = ['id'];
+		if ($extractFileIds === true) {
+			$ignoredAttributes = [];
+		}
 
 		$filename = Path::join($exportPath, $this::FILE_NAME);
 		$this->streamFile = $this->streamHelper->initStream($filename, 'ab', true);
@@ -68,9 +73,10 @@ class FilesMetadataExtractor {
 			->setPath('/')
 			->setETag($baseFolder->getEtag())
 			->setMtime($baseFolder->getMTime())
-			->setPermissions($baseFolder->getPermissions());
+			->setPermissions($baseFolder->getPermissions())
+			->setId($baseFolder->getId());
 
-		$this->streamHelper->writelnToStream($this->streamFile, $rootFolder);
+		$this->streamHelper->writelnToStream($this->streamFile, $rootFolder, $ignoredAttributes);
 
 		foreach ($iterator as $node) {
 			$nodePath = $node->getPath();
@@ -98,7 +104,7 @@ class FilesMetadataExtractor {
 				$file->setType(File::TYPE_FOLDER);
 			}
 
-			$this->streamHelper->writelnToStream($this->streamFile, $file);
+			$this->streamHelper->writelnToStream($this->streamFile, $file, $ignoredAttributes);
 		}
 		$this->streamHelper->closeStream($this->streamFile);
 	}

--- a/lib/Extractor/MetadataExtractor/FilesMetadataExtractor.php
+++ b/lib/Extractor/MetadataExtractor/FilesMetadataExtractor.php
@@ -90,6 +90,7 @@ class FilesMetadataExtractor {
 			$file->setETag($node->getEtag());
 			$file->setMtime($node->getMTime());
 			$file->setPermissions($node->getPermissions());
+			$file->setId($node->getId());
 
 			if ($node->getType() === Node::TYPE_FILE) {
 				$file->setType(File::TYPE_FILE);

--- a/lib/Model/File.php
+++ b/lib/Model/File.php
@@ -34,7 +34,10 @@ class File {
 	const TYPE_FILE = 'file';
 	const ROOT_FOLDER_PATH = '/files/';
 
+	/** @var string */
 	private $type;
+	/** @var int */
+	private $id;
 	/** @var string */
 	private $path;
 	/** @var mixed */
@@ -58,6 +61,20 @@ class File {
 	public function setType($type) {
 		$this->type = $type;
 		return $this;
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getId() {
+		return $this->id;
+	}
+
+	/**
+	 * @param mixed $id
+	 */
+	public function setId($id) {
+		$this->id = (int) $id;
 	}
 
 	/**

--- a/lib/Model/File.php
+++ b/lib/Model/File.php
@@ -72,9 +72,11 @@ class File {
 
 	/**
 	 * @param mixed $id
+	 * @return File
 	 */
 	public function setId($id) {
 		$this->id = (int) $id;
+		return $this;
 	}
 
 	/**

--- a/lib/Serializer.php
+++ b/lib/Serializer.php
@@ -32,13 +32,16 @@ class Serializer {
 
 	/** @var \Symfony\Component\Serializer\Serializer  */
 	private $serializer;
+	/** @var ObjectNormalizer  */
+	private $objectNormalizer;
 
 	public function __construct() {
+		$this->objectNormalizer = new ObjectNormalizer(null, null, null, new PhpDocExtractor());
 		$encoders = [new JsonEncoder()];
 		$normalizers = [
 			new DateTimeNormalizer(),
 			new ArrayDenormalizer(),
-			new ObjectNormalizer(null, null, null, new PhpDocExtractor())
+			$this->objectNormalizer,
 		];
 
 		$this->serializer = new \Symfony\Component\Serializer\Serializer($normalizers, $encoders);
@@ -65,5 +68,9 @@ class Serializer {
 	 */
 	public function deserialize($data, $type) {
 		return $this->serializer->deserialize($data, $type, 'json', []);
+	}
+
+	public function setIgnoredAttributes($attributes = []) {
+		$this->objectNormalizer->setIgnoredAttributes($attributes);
 	}
 }

--- a/lib/Utilities/StreamHelper.php
+++ b/lib/Utilities/StreamHelper.php
@@ -85,10 +85,13 @@ class StreamHelper {
 	 * @param resource $resource
 	 * @param Share | File $entity
 	 *
+	 * @param array $ignoreAttributes
 	 * @return void
 	 */
-	public function writelnToStream($resource, $entity) {
+	public function writelnToStream($resource, $entity, $ignoreAttributes = []) {
+		$this->serializer->setIgnoredAttributes($ignoreAttributes);
 		$data = $this->serializer->serialize($entity);
+		$this->serializer->setIgnoredAttributes([]);
 		\fwrite($resource, $data . PHP_EOL);
 	}
 

--- a/tests/unit/Utilities/StreamHelperTest.php
+++ b/tests/unit/Utilities/StreamHelperTest.php
@@ -85,8 +85,8 @@ class StreamHelperTest extends TestCase {
 		$this->streamHelper->closeStream($resource);
 		$writtenData = \file_get_contents($virtualFilesystem->url() . '/testfolder/files.jsonl');
 		$expectedData = <<< JSONL
-{"type":"file","path":"files\/welcome.txt","eTag":"234s34ser234","permissions":31,"mtime":1565267598}
-{"type":"folder","path":"files\/someFolder","eTag":"234s34ser234","permissions":31,"mtime":1565267598}
+{"type":"file","id":null,"path":"files\/welcome.txt","eTag":"234s34ser234","permissions":31,"mtime":1565267598}
+{"type":"folder","id":null,"path":"files\/someFolder","eTag":"234s34ser234","permissions":31,"mtime":1565267598}
 
 JSONL;
 		$this->assertEquals($expectedData, $writtenData);


### PR DESCRIPTION
Required if files are exported directly from objectstore they are placed in a flat directory hierarchy where the file is named like the file-id.