### PR TITLE
obj2localstore tool

### DIFF
--- a/tools/obj2localstore/.gitignore
+++ b/tools/obj2localstore/.gitignore
@@ -1,0 +1,3 @@
+obj2localstore
+rollback.txt
+.idea

--- a/tools/obj2localstore/Makefile
+++ b/tools/obj2localstore/Makefile
@@ -1,0 +1,8 @@
+.PHONY: clean obj2localstore
+obj2localstore:
+	go build
+
+clean:
+	rm -f obj2localstore rollback.txt
+
+

--- a/tools/obj2localstore/README.md
+++ b/tools/obj2localstore/README.md
@@ -1,0 +1,88 @@
+# obj2localstore
+Moves a flat directory of exported files in to their respective localstorage-structure
+using exported metadata (files.jsonl)
+
+## Example
+Export metadata of one or multiple users:
+```
+$ occ instance:export:user --no-files --with-file-ids admin /var/export
+$ occ instance:export:user --no-files --with-file-ids user1 /var/export  
+```
+
+Download all files from a swift-objectstore owncloud-bucket:
+```
+$ pwd
+/var/owncloud_objects
+$ swift --os-auth-url http://localhost:8080/v2.0 \
+                       --os-tenant-name AUTH_test \
+                       --os-username test \ 
+                       --os-password test \ 
+                       \ download  --all --object-threads=8
+
+owncloud/urn:oid:123 [auth 0.126s, headers 0.141s, total 0.142s, 0.243 MB/s]
+owncloud/urn:oid:110 [auth 0.000s, headers 0.012s, total 0.012s, 0.055 MB/s]
+owncloud/urn:oid:119 [auth 0.000s, headers 0.013s, total 0.014s, 15.158 MB/s]
+...
+```
+This results in an export-directory with meta-data and a flat directory with all file-object of the instance
+named like the file-id:
+```
+$ tree /var/export
+/var/export
+├── admin
+│   ├── files.jsonl
+│   ├── shares.jsonl
+│   └── user.json
+└── user1
+    ├── files.jsonl
+    ├── shares.jsonl
+    └── user.json
+
+$ tree /var/owncloud_objects
+owncloud_objects
+├── urn:oid:123
+├── urn:oid:110
+├── urn:oid:119
+|-- ...
+```
+
+
+Invoke obj2localstore to move the files in to it respective user-dir inside the /files directory of the export to replicate
+owncloud localstorage-layout
+```
+~/c/c/a/d/t/obj2localstore:λ ./obj2localstore /var/owncloud_objects /var/export
+2019/11/27 18:22:49 Creating userdir for /var/export/admin/files.jsonl
+2019/11/27 18:22:49 Created Directory: /var/export/admin/files
+2019/11/27 18:22:49 Created Directory: /var/export/admin/files/Documents
+2019/11/27 18:22:49 Moved /var/owncloud_objects/owncloud/urn:oid:107 to /var/export/admin/files/Documents/AnotherTest.txt
+2019/11/27 18:22:49 Moved /var/owncloud_objects/owncloud/urn:oid:99 to /var/export/admin/files/Documents/SINAG.txt
+2019/11/27 18:22:49 Creating userdir for /var/export/user1/files.jsonl
+2019/11/27 18:22:49 Created Directory: /var/export/user1/files
+2019/11/27 18:22:49 Created Directory: /var/export/user1/files/Documents
+2019/11/27 18:22:49 Moved /var/owncloud_objects/owncloud/urn:oid:115 to /var/export/user1/files/Documents/Example.odt
+2019/11/27 18:22:49 Moved /var/owncloud_objects/owncloud/urn:oid:120 to /var/export/user1/files/Documents/sU.txt
+2019/11/27 18:22:49 Created Directory: /var/export/user1/files/Photos
+2019/11/27 18:22:49 Moved /var/owncloud_objects/owncloud/urn:oid:117 to /var/export/user1/files/Photos/Paris.jpg
+2019/11/27 18:22:49 Moved /var/owncloud_objects/owncloud/urn:oid:119 to /var/export/user1/files/Photos/San Francisco.jpg
+2019/11/27 18:22:49 Moved /var/owncloud_objects/owncloud/urn:oid:118 to /var/export/user1/files/Photos/Squirrel.jpg
+```
+
+A rollback.txt with shell move operations is created to reverse all moves if something goes wrong. 
+
+```
+$ cat rollback.txt 
+mv /var/export/admin/files/Documents/AnotherTest.txt /var/owncloud_objects/owncloud/urn:oid:107
+mv /var/export/admin/files/Documents/SINAG.txt /var/owncloud_objects/owncloud/urn:oid:99
+mv /var/export/user1/files/Documents/Example.odt /var/owncloud_objects/owncloud/urn:oid:115
+mv /var/export/user1/files/Documents/sU.txt /var/owncloud_objects/owncloud/urn:oid:120
+mv /var/export/user1/files/Photos/Paris.jpg /var/owncloud_objects/owncloud/urn:oid:117
+mv /var/export/user1/files/Photos/San Francisco.jpg /var/owncloud_objects/owncloud/urn:oid:119
+mv /var/export/user1/files/Photos/Squirrel.jpg /var/owncloud_objects/owncloud/urn:oid:118
+mv /var/export/admin/files/Documents/AnotherTest.txt /var/owncloud_objects/owncloud/urn:oid:107
+mv /var/export/admin/files/Documents/SINAG.txt /var/owncloud_objects/owncloud/urn:oid:99
+mv /var/export/user1/files/Documents/Example.odt /var/owncloud_objects/owncloud/urn:oid:115
+mv /var/export/user1/files/Documents/sU.txt /var/owncloud_objects/owncloud/urn:oid:120
+mv /var/export/user1/files/Photos/Paris.jpg /var/owncloud_objects/owncloud/urn:oid:117
+mv /var/export/user1/files/Photos/San Francisco.jpg /var/owncloud_objects/owncloud/urn:oid:119
+mv /var/export/user1/files/Photos/Squirrel.jpg /var/owncloud_objects/owncloud/urn:oid:118
+```

--- a/tools/obj2localstore/main.go
+++ b/tools/obj2localstore/main.go
@@ -1,0 +1,139 @@
+/**
+ * Author Ilja Neumann <ineumann@owncloud.com>
+ *
+ * Copyright (c) 2019, ownCloud GmbH
+ * License GPL-2.0
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path"
+	"path/filepath"
+)
+
+const Usage = `Usage: obj2localstore objectPath exportPath
+
+  objectPath - Directory which contains files in urn:oid:$fileId form.
+  exportPath - Directory which contains the export of one or multiple users`
+
+type File struct {
+	Id   int    `json:"id"`
+	Type string `json:"type"`
+	Path string `json:"path"`
+}
+
+func init() {
+	args := os.Args[1:]
+	if len(args) != 2 {
+		fmt.Println(Usage)
+		os.Exit(1)
+	}
+}
+
+func main() {
+	args := os.Args[1:]
+	objectDir := args[0]
+	exportPath := args[1]
+
+	exportFiles, err := ioutil.ReadDir(exportPath)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, f := range exportFiles {
+		if !f.IsDir() {
+			continue
+		}
+
+		metaDataPath := path.Join(exportPath, f.Name(), "files.jsonl")
+		filePath := path.Join(exportPath, f.Name(), "files")
+		if _, err := os.Stat(metaDataPath); err != nil {
+			log.Println(err)
+		} else {
+			log.Printf("Creating userdir for %v", metaDataPath)
+			buildUserDir(metaDataPath, filePath, objectDir)
+		}
+	}
+
+}
+
+func buildUserDir(metaDataPath string, filesPath string, objectDir string) {
+
+	rollbackLog, err := os.OpenFile("./rollback.txt", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		log.Println(err)
+	}
+
+	defer rollbackLog.Close()
+
+	forEachFile(metaDataPath, func(f *File) {
+		fullPath := path.Join(filesPath, f.Path)
+		if f.Type == "folder" {
+			if err := os.MkdirAll(fullPath, 0777); err != nil {
+				log.Fatal(err)
+			}
+
+			log.Printf("Created Directory: %v", fullPath)
+			return
+		}
+
+		if f.Type == "file" {
+			if _, err := os.Stat(fullPath); os.IsNotExist(err) {
+				fileDir := filepath.Dir(fullPath)
+				if err := os.MkdirAll(fileDir, 0777); err != nil {
+					log.Fatal("Error creating missing directory for file", err)
+				}
+			}
+
+			objectFilePath := path.Join(objectDir, fmt.Sprintf("urn:oid:%v", f.Id))
+			if err := os.Rename(objectFilePath, fullPath); err != nil {
+				log.Fatal(err)
+			}
+
+			log.Printf("Moved %v to %v", objectFilePath, fullPath)
+			if _, err := rollbackLog.WriteString(fmt.Sprintf("mv %v %v\n", fullPath, objectFilePath)); err != nil {
+				log.Fatal("Error writing rollback-file:", err)
+			}
+		}
+	})
+}
+
+//Callback iterator for files.jsonl
+func forEachFile(path string, fn func(metaData *File)) {
+	filesJSONL, err := os.Open(path)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	defer filesJSONL.Close()
+	jsonLines := bufio.NewScanner(filesJSONL)
+	for jsonLines.Scan() {
+		var f File
+		if err := json.Unmarshal(jsonLines.Bytes(), &f); err != nil {
+			log.Fatal(err)
+		}
+
+		fn(&f)
+	}
+}


### PR DESCRIPTION
Moves a flat directory of exported files in to their respective localstorage-structure
using exported metadata (files.jsonl)