### PR TITLE
Add phpdoc for Symfony Command execute

### DIFF
--- a/lib/Command/ExportUser.php
+++ b/lib/Command/ExportUser.php
@@ -48,6 +48,14 @@ class ExportUser extends Command {
 			->addOption('with-file-ids', 'i', InputOption::VALUE_NONE, 'Export file-ids in file-metadata');
 	}
 
+	/**
+	 * Executes the current command.
+	 *
+	 * @param InputInterface $input
+	 * @param OutputInterface $output
+	 *
+	 * @return int|null|void
+	 */
 	protected function execute(InputInterface $input, OutputInterface $output) {
 		try {
 			$this->exporter->export(

--- a/lib/Command/ImportUser.php
+++ b/lib/Command/ImportUser.php
@@ -46,6 +46,14 @@ class ImportUser extends Command {
 			->addOption('as', 'a', InputOption::VALUE_REQUIRED, 'Import the user under a different user id');
 	}
 
+	/**
+	 * Executes the current command.
+	 *
+	 * @param InputInterface $input
+	 * @param OutputInterface $output
+	 *
+	 * @return int|null|void
+	 */
 	protected function execute(InputInterface $input, OutputInterface $output) {
 		try {
 			$this->importer->import(


### PR DESCRIPTION
## Description
`phan` is complaining:
https://drone.owncloud.com/owncloud/data_exporter/954/3/3
```
php -d zend.enable_gc=0 vendor-bin/phan/vendor/bin/phan --config-file .phan/config.php --require-config-exists
lib/Command/ExportUser.php:51 PhanTypeMissingReturn Method \OCA\DataExporter\Command\ExportUser::execute is declared to return int but has no return value
lib/Command/ImportUser.php:49 PhanTypeMissingReturn Method \OCA\DataExporter\Command\ImportUser::execute is declared to return int but has no return value
make: *** [test-php-phan] Error 1
```
This is because some Symfony4 comes in core now, and the `execute` method there has phpdoc that declares a return of `int`.

Add phpdoc the same as in other command code - e.g. from `ExportInstance.php`

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

