### PR TITLE
[Tests-Only] Fix unit tests related to core issue 37358 and core PR 37103

### DIFF
--- a/tests/unit/Extractor/MetadataExtractor/UserExtractorTest.php
+++ b/tests/unit/Extractor/MetadataExtractor/UserExtractorTest.php
@@ -61,8 +61,8 @@ class UserExtractorTest extends TestCase {
 			->willReturn(true);
 		$this->userManager
 			->method('get')->willReturnMap([
-				['jcache', $mockUser],
-				['doesnotexist', null]
+				['jcache', false, $mockUser],
+				['doesnotexist', false, null]
 		]);
 
 		$this->groupManager = $this->createMock(IGroupManager::class);


### PR DESCRIPTION
Part of issue https://github.com/owncloud/core/issues/37358

The signature of core `lib/private/User/Manager.php` `get()` changed to have a new 2nd parameter.
See core PR https://github.com/owncloud/core/pull/37103

Adjust unit tests so that the mocking of userManager matches the way that phpunit sees the calls. Even though the new parameter is optional (has a default value), phpunit sees the call happening with the parameter having been set to its default value `false`