### PR TITLE
Put new bootstrapFiles section in phpstan.neon

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,6 +1,5 @@
 parameters:
-  bootstrap: %currentWorkingDirectory%/../../lib/base.php
-  excludes_analyse:
-    - %currentWorkingDirectory%/appinfo/register_command.php
+  bootstrapFiles:
+    - %currentWorkingDirectory%/../../lib/base.php
   ignoreErrors:
 


### PR DESCRIPTION
That is new since `phpstan` 0.12.26

And `phpstan`  can analyze more stuff now, so remove the `excludes_analyse` section.