### PR TITLE
[Tests-Only] Adjust PHPdoc for phpstan

### DIFF
--- a/appinfo/register_command.php
+++ b/appinfo/register_command.php
@@ -5,7 +5,7 @@ $config = \OC::$server->getConfig();
 $ocVersion = $config->getSystemValue('version', '');
 
 /**
- * @var Symfony\Component\Console\Application $application
+ * @var Symfony\Component\Console\Application|null $application
  */
 if (isset($application) && \version_compare($ocVersion, '10', '<')) {
 	$exporter = \OC::$server->query(\OCA\DataExporter\Exporter::class);


### PR DESCRIPTION
## Description
The latest `phpstan` `0.12.30` recognises that the PHPdoc for `$application` claims that it is always set. So last night it complained:
https://drone.owncloud.com/owncloud/data_exporter/1190/2/5
```
php -d zend.enable_gc=0 vendor-bin/phpstan/vendor/bin/phpstan analyse --memory-limit=4G --configuration=./phpstan.neon --no-progress --level=5 appinfo lib
 ------ --------------------------------------------------------------------- 
  Line   appinfo/register_command.php                                         
 ------ --------------------------------------------------------------------- 
  10     Variable $application in isset() always exists and is not nullable.  
 ------ --------------------------------------------------------------------- 

 [ERROR] Found 1 error
```

Adjust the PHPdoc so it admits that the var could be `null`. That stops `phpstan` from complaining about the "unnecessary" `isset()` check.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

