### PR TITLE
Adjust drone CI coverage reporting

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -915,8 +915,6 @@ def acceptance():
 										'refs/pull/**',
 										'refs/tags/**'
 									]
-									for branch in config['branches']:
-										result['trigger']['ref'].append('refs/heads/%s' % branch)
 								else:
 									result['trigger']['cron'] = params['cron']
 


### PR DESCRIPTION
1) Do not run acceptance tests in merge CI - issue https://github.com/owncloud/QA/issues/648
2) Send unit test coverage and code analysis to SonarCloud (coming...) https://github.com/owncloud/QA/issues/649

This repo has both "unit" and "integration" PHPunit tests, so it should be a good place to make a "template" change that can be applied the same in other oC10 app repos.