### PR TITLE
Suppress PhanDeprecatedFunction for doctrine/dbal changes

### DIFF
--- a/lib/Extractor/MetadataExtractor/TrashBinExtractor/GetLocationQuery.php
+++ b/lib/Extractor/MetadataExtractor/TrashBinExtractor/GetLocationQuery.php
@@ -49,6 +49,7 @@ class GetLocationQuery {
 	 */
 	public function execute($uid, $filename, $timestamp) {
 		$qb = $this->db->getQueryBuilder();
+		/* @phan-suppress-next-line PhanDeprecatedFunction */
 		$location = $qb->from('files_trash')
 			->select('location')
 			->where($qb->expr()->eq('user', $qb->createNamedParameter($uid)))

--- a/lib/Extractor/MetadataExtractor/UserExtractor/GetPasswordHashQuery.php
+++ b/lib/Extractor/MetadataExtractor/UserExtractor/GetPasswordHashQuery.php
@@ -47,6 +47,7 @@ class GetPasswordHashQuery {
 	 */
 	public function execute($uid) {
 		$qb = $this->db->getQueryBuilder();
+		/* @phan-suppress-next-line PhanDeprecatedFunction */
 		$password = $qb->from('users')
 			->select('password')
 			->where($qb->expr()->eq('uid', $qb->createNamedParameter($uid)))


### PR DESCRIPTION
`doctrine/dbal` was updated yesterday in core https://github.com/owncloud/core/pull/38647

Some methods have been deprecated, and `phan` reports those and fails the CI.

Suppress the deprecation warnings for now.

I raised issue #185 to actually adjust the code "some time".