### PR TITLE
[tests-only][full-ci]Tidy up the phpunit xml file for data_exporter app

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -6,32 +6,28 @@
 		 failOnWarning="true"
 		 timeoutForSmallTests="900"
 		 timeoutForMediumTests="900"
-		 timeoutForLargeTests="900"
->
-	<testsuites>
-		<testsuite name='unit'>
-			<directory suffix=".php">./tests/unit</directory>
-		</testsuite>
-		<testsuite name='integration'>
-			<directory suffix=".php">./tests/integration</directory>
-		</testsuite>
-	</testsuites>
-	<!-- filters for code coverage -->
-	<filter>
-		<whitelist>
-			<directory suffix=".php">../data_exporter</directory>
-			<exclude>
-				<directory suffix=".php">../data_exporter/.phan</directory>
-				<directory suffix=".php">../data_exporter/l10n</directory>
-				<directory suffix=".php">../data_exporter/tests</directory>
-				<directory suffix=".php">../data_exporter/vendor</directory>
-				<directory suffix=".php">../data_exporter/vendor-bin</directory>
-			</exclude>
-		</whitelist>
-	</filter>
-	<logging>
-		<!-- and this is where your report will be written -->
-		<log type="coverage-clover" target="./tests/output/clover.xml"/>
-	</logging>
+		 timeoutForLargeTests="900">
+  <testsuites>
+  	<testsuite name='unit'>
+  	 <directory suffix=".php">./tests/unit</directory>
+  	</testsuite>
+  	<testsuite name='integration'>
+  	 <directory suffix=".php">./tests/integration</directory>
+  	</testsuite>
+  </testsuites>
+  <coverage>
+    <include>
+		<directory suffix=".php">../data_exporter</directory>
+    </include>
+	<exclude>
+		<directory suffix=".php">../data_exporter/.phan</directory>
+		<directory suffix=".php">../data_exporter/l10n</directory>
+		<directory suffix=".php">../data_exporter/tests</directory>
+		<directory suffix=".php">../data_exporter/vendor</directory>
+		<directory suffix=".php">../data_exporter/vendor-bin</directory>
+	</exclude>
+    <report>
+      <clover outputFile="./tests/output/clover.xml"/>
+    </report>
+  </coverage>
 </phpunit>
-


### PR DESCRIPTION
This PR moves unit tests into tests/unit folder. And also tidy up the `phpunit.xml` to make standard format for all oc-apps as much as possible.

- Part of https://github.com/owncloud/impersonate/issues/198