### PR TITLE
Fix isAppEnabledForUser check

### DIFF
--- a/appinfo/register_command.php
+++ b/appinfo/register_command.php
@@ -11,7 +11,11 @@ if (isset($application) && \version_compare($ocVersion, '10', '<')) {
 	$exporter = \OC::$server->query(\OCA\DataExporter\Exporter::class);
 	$platform = \OC::$server->query(\OCA\DataExporter\Exporter::class);
 	$application->add(
-		new \OCA\DataExporter\Command\ExportUser($exporter, $platform)
+		new \OCA\DataExporter\Command\ExportUser(
+			$exporter,
+			$platform,
+			\OC::$server->getUserManager()
+		)
 	);
 }
 // @codeCoverageIgnoreEnd

--- a/lib/Command/ExportInstance.php
+++ b/lib/Command/ExportInstance.php
@@ -76,6 +76,7 @@ class ExportInstance extends Command {
 			);
 		} catch (\Exception $e) {
 			$output->writeln("<error>{$e->getMessage()}</error>");
+			return 1;
 		}
 	}
 }

--- a/lib/Command/ExportUser.php
+++ b/lib/Command/ExportUser.php
@@ -24,6 +24,7 @@ namespace OCA\DataExporter\Command;
 
 use OCA\DataExporter\Exporter;
 use OCA\DataExporter\Platform;
+use OCP\IUserManager;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -38,10 +39,14 @@ class ExportUser extends Command {
 	/** @var Platform  */
 	private $platform;
 
-	public function __construct(Exporter $exporter, Platform $platform) {
+	/** @var IUserManager */
+	private $userManager;
+
+	public function __construct(Exporter $exporter, Platform $platform, IUserManager $userManager) {
 		parent::__construct();
 		$this->exporter = $exporter;
 		$this->platform = $platform;
+		$this->userManager = $userManager;
 	}
 
 	protected function configure() {
@@ -65,9 +70,10 @@ class ExportUser extends Command {
 		try {
 			$uid = $input->getArgument('userId');
 			$exportDirectory = $input->getArgument('exportDirectory');
+			$user = $this->userManager->get($uid);
 			$this->exporter->export($uid, $exportDirectory, [
 				'exportFiles' => !$input->getOption('no-files'),
-				'trashBinAvailable' => $this->platform->isAppEnabledForUser('files_trashbin', $uid),
+				'trashBinAvailable' => $this->platform->isAppEnabledForUser('files_trashbin', $user),
 				'exportFileIds' => $input->getOption('with-file-ids')
 			]);
 		} catch (\Exception $e) {

--- a/lib/Command/ExportUser.php
+++ b/lib/Command/ExportUser.php
@@ -78,6 +78,7 @@ class ExportUser extends Command {
 			]);
 		} catch (\Exception $e) {
 			$output->writeln("<error>{$e->getMessage()}</error>");
+			return 1;
 		}
 	}
 }

--- a/lib/Command/ImportInstance.php
+++ b/lib/Command/ImportInstance.php
@@ -76,6 +76,7 @@ class ImportInstance extends Command {
 			);
 		} catch (\Exception $e) {
 			$output->writeln("<error>{$e->getMessage()}</error>");
+			return 1;
 		}
 	}
 }

--- a/lib/Command/ImportUser.php
+++ b/lib/Command/ImportUser.php
@@ -62,6 +62,7 @@ class ImportUser extends Command {
 			);
 		} catch (\Exception $e) {
 			$output->writeln("<error>{$e->getMessage()}</error>");
+			return 1;
 		}
 	}
 }

--- a/lib/Platform.php
+++ b/lib/Platform.php
@@ -66,7 +66,14 @@ class Platform {
 		return $this->version['OC_VersionString'];
 	}
 
-	public function isAppEnabledForUser($appId, $uid) {
-		return $this->appManager->isEnabledForUser($appId, $uid);
+	/**
+	 * Check if an app is enabled for user
+	 *
+	 * @param string $appId
+	 * @param \OCP\IUser $user
+	 * @return bool
+	 */
+	public function isAppEnabledForUser($appId, $user) {
+		return $this->appManager->isEnabledForUser($appId, $user);
 	}
 }

--- a/tests/acceptance/features/bootstrap/DataExporterContext.php
+++ b/tests/acceptance/features/bootstrap/DataExporterContext.php
@@ -238,9 +238,11 @@ class DataExporterContext implements Context {
 		$importPath = self::path("$this->dataDir/$path");
 		$this->featureContext->runOcc(['instance:import:user', $importPath]);
 
-		$meta = \json_decode(\file_get_contents("$importPath/user.json"), true);
-		if (isset($meta['user'], $meta['user']['userId'])) {
-			$this->importedUsers[] = $meta['user']['userId'];
+		if ($this->occContext->theOccCommandExitStatusWasSuccess()) {
+			$meta = \json_decode(\file_get_contents("$importPath/user.json"), true);
+			if (isset($meta['user'], $meta['user']['userId'])) {
+				$this->importedUsers[] = $meta['user']['userId'];
+			}
 		}
 	}
 

--- a/tests/acceptance/features/cliDataExporter/export.feature
+++ b/tests/acceptance/features/cliDataExporter/export.feature
@@ -63,3 +63,8 @@ Feature: An administrator wants to export the files of his user using
       | '"quotes1"'             |
       | "'quotes2'"             |
       | "strängé नेपाली folder" |
+
+  Scenario: An attempt to export an unknown user should fail
+    When user "unknown" is exported to path "/tmp/fooSomething" using the occ command
+    Then the command should have failed with exit code 1
+    And the command output should contain the text "Could not extract user metadata for user"

--- a/tests/acceptance/features/cliDataExporter/import.feature
+++ b/tests/acceptance/features/cliDataExporter/import.feature
@@ -74,3 +74,8 @@ Feature: An administrator wants to import a user using the commandline
     Then the HTTP status code should be "201"
     And as "testUser" file "/testFile.txt" should exist
     And the content of file "/testFile.txt" for user "testUser" should be "text in file in deleted folder"
+
+  Scenario: An attempt to import from a non-existent export should fail
+    When a user is imported from path "simpleExport/unknown" using the occ command
+    Then the command should have failed with exit code 1
+    And the command output should contain the text "user.json not found"

--- a/tests/unit/Command/ExportUserTest.php
+++ b/tests/unit/Command/ExportUserTest.php
@@ -25,10 +25,14 @@ namespace OCA\DataExporter\Tests\Unit\Command;
 use OCA\DataExporter\Command\ExportUser;
 use OCA\DataExporter\Exporter;
 use OCA\DataExporter\Platform;
+use OCP\IUserManager;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 
 class ExportUserTest extends TestCase {
+
+	/** @var IUserManager */
+	private $userManager;
 
 	/** @var \PHPUnit_Framework_MockObject_MockObject|Exporter */
 	private $exporter;
@@ -38,8 +42,13 @@ class ExportUserTest extends TestCase {
 
 	public function setUp(): void {
 		$this->exporter = $this->getMockBuilder(Exporter::class)->disableOriginalConstructor()->getMock();
+		$this->userManager = \OC::$server->getUserManager();
 
-		$command = new ExportUser($this->exporter, $this->createMock(Platform::class));
+		$command = new ExportUser(
+			$this->exporter,
+			$this->createMock(Platform::class),
+			$this->userManager
+		);
 		$this->commandTester = new CommandTester($command);
 	}
 


### PR DESCRIPTION
## Description
1) The ExportUser command calls `isAppEnabledForUser` but passes just the string value "uid" (the username). But the core method expects to be passed an `OCP/IUser` object.

Up to now, this error was not noticed. Tests had to call `isAppEnabledForUser` in an environment where there were combinations of apps whitelisted for various groups - that was the only situation when the parameter passed in was actually used as an `IUser` object.

Core PR https://github.com/owncloud/core/pull/40257 was merged yesterday. That added more code to `isAppEnabledForUser`, and that meant that the error in the data_exporter app is now causing test failures.

This PR fixes the calls. It is all backward-compatible with previous versions of oC10 core - so there is no need to increase the core min-version.

2) while I was trying export and import commands, I noticed that they always exit with "0" (success) status at the command line. The 2nd commit adds code to make them exit with status 1 in case of error.

## Related Issue
Fixes #205 

## How Has This Been Tested?
Local run of test scenario:
```
$ make test-acceptance-cli BEHAT_FEATURE=tests/acceptance/features/cliDataExporter/export.feature:9
```

It fails before the code change, and passes after the code change.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
