### PR TITLE
[tests-only] Save exitcode of last occ command

### DIFF
--- a/tests/acceptance/features/bootstrap/DataExporterContext.php
+++ b/tests/acceptance/features/bootstrap/DataExporterContext.php
@@ -165,7 +165,9 @@ class DataExporterContext implements Context {
 		$internalPath = self::path("{$this->scenarioDir}/$path");
 		$serverRoot = $this->featureContext->getServerRoot();
 		$this->featureContext->mkDirOnServer($internalPath);
-		$this->featureContext->runOcc(['instance:export:user', $user, self::path("$serverRoot/$internalPath")]);
+		$this->featureContext->setOccLastCode(
+			$this->featureContext->runOcc(['instance:export:user', $user, self::path("$serverRoot/$internalPath")])
+		);
 
 		$this->lastExportBasePath = $internalPath;
 		$this->lastExportPath = self::path("{$this->lastExportBasePath}/$user/");
@@ -236,7 +238,9 @@ class DataExporterContext implements Context {
 	 */
 	public function importUserUsingTheOccCommand(string $path):void {
 		$importPath = self::path("$this->dataDir/$path");
-		$this->featureContext->runOcc(['instance:import:user', $importPath]);
+		$this->featureContext->setOccLastCode(
+			$this->featureContext->runOcc(['instance:import:user', $importPath])
+		);
 
 		if ($this->occContext->theOccCommandExitStatusWasSuccess()) {
 			$meta = \json_decode(\file_get_contents("$importPath/user.json"), true);


### PR DESCRIPTION
## Description
The PR https://github.com/owncloud/core/pull/40359 has implemented different method to save the exitcode of the last occ command and the local tests were failing because the exitcode was not saved.
In this PR, I have implemented the updated way to save the occ exitCode.


## Related Issue
Fixes https://github.com/owncloud/data_exporter/issues/212

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

