### PR TITLE
Always return an int from Symfony Command execute method

### DIFF
--- a/lib/Command/ExportInstance.php
+++ b/lib/Command/ExportInstance.php
@@ -67,9 +67,9 @@ class ExportInstance extends Command {
 	 * @param InputInterface $input
 	 * @param OutputInterface $output
 	 *
-	 * @return int|null|void
+	 * @return int
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		try {
 			$this->instanceExporter->export(
 				$input->getArgument('exportDirectory')
@@ -78,5 +78,6 @@ class ExportInstance extends Command {
 			$output->writeln("<error>{$e->getMessage()}</error>");
 			return 1;
 		}
+		return 0;
 	}
 }

--- a/lib/Command/ExportUser.php
+++ b/lib/Command/ExportUser.php
@@ -64,9 +64,9 @@ class ExportUser extends Command {
 	 * @param InputInterface $input
 	 * @param OutputInterface $output
 	 *
-	 * @return int|null|void
+	 * @return int
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		try {
 			$uid = $input->getArgument('userId');
 			$exportDirectory = $input->getArgument('exportDirectory');
@@ -80,5 +80,6 @@ class ExportUser extends Command {
 			$output->writeln("<error>{$e->getMessage()}</error>");
 			return 1;
 		}
+		return 0;
 	}
 }

--- a/lib/Command/ImportInstance.php
+++ b/lib/Command/ImportInstance.php
@@ -67,9 +67,9 @@ class ImportInstance extends Command {
 	 * @param InputInterface $input
 	 * @param OutputInterface $output
 	 *
-	 * @return int|null|void
+	 * @return int
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		try {
 			$this->instanceImporter->import(
 				$input->getArgument('importDirectory')
@@ -78,5 +78,6 @@ class ImportInstance extends Command {
 			$output->writeln("<error>{$e->getMessage()}</error>");
 			return 1;
 		}
+		return 0;
 	}
 }

--- a/lib/Command/ImportUser.php
+++ b/lib/Command/ImportUser.php
@@ -52,9 +52,9 @@ class ImportUser extends Command {
 	 * @param InputInterface $input
 	 * @param OutputInterface $output
 	 *
-	 * @return int|null|void
+	 * @return int
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		try {
 			$this->importer->import(
 				$input->getArgument('importDirectory'),
@@ -64,5 +64,6 @@ class ImportUser extends Command {
 			$output->writeln("<error>{$e->getMessage()}</error>");
 			return 1;
 		}
+		return 0;
 	}
 }

--- a/lib/Command/MigrateShare.php
+++ b/lib/Command/MigrateShare.php
@@ -56,7 +56,7 @@ class MigrateShare extends Command {
 			->addArgument('remoteServer', InputArgument::REQUIRED, 'The remote ownCloud server where the exported user is now, for example "https://myown.server:8080/owncloud"');
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		/** @var string $userId */
 		$userId = $input->getArgument('userId');
 		if (!$this->userManager->userExists($userId)) {


### PR DESCRIPTION
## Description
Symfony 5 will require this, so be prepared.
For Symfony 4 it is optional.

Preparation for https://github.com/owncloud/core/issues/39630

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

