### PR TITLE
[tests-only] [full-ci] exporting with empty trash bin

### DIFF
--- a/tests/acceptance/features/cliDataExporter/export.feature
+++ b/tests/acceptance/features/cliDataExporter/export.feature
@@ -74,3 +74,13 @@ Feature: An administrator wants to export the files of his user using
     When user "unknown" is exported to path "/tmp/fooSomething" using the occ command
     Then the command should have failed with exit code 1
     And the command output should contain the text "Could not extract user metadata for user"
+
+  @issue-209
+  Scenario: export a user after clearing out the items in their trash bin
+    Given user "Alice" has uploaded file with content "hello" to "testfile1.txt"
+    And user "Alice" has uploaded file with content "hello world" to "testfile2.txt"
+    And user "Alice" has deleted file "/testfile1.txt"
+    And user "Alice" has emptied the trashbin
+    When user "Alice" is exported to path "/tmp/fooSomething" using the occ command
+    Then the command should have been successful
+    And the last export should contain file "/testfile2.txt" with content "hello world"

--- a/tests/acceptance/features/cliDataExporter/exportFileWithEmptyTrashBinDataExporterIssue209.feature
+++ b/tests/acceptance/features/cliDataExporter/exportFileWithEmptyTrashBinDataExporterIssue209.feature
@@ -1,0 +1,12 @@
+@cli @issue-209
+Feature: an administrator wants to export the files of the user using the command line
+
+
+  Scenario: export a user before any resources are deleted
+    Given using new dav path
+    And user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file with content "hello world" to "testfile1.txt"
+    When user "Alice" is exported to path "/tmp/fooSomething" using the occ command
+    Then the command should have failed with exit code 1
+    And the command output should contain the text "/Alice/files_trashbin/files"
+    But the last export should contain file "/testfile1.txt" with content "hello world"


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
This PR has the scenario of exporting with empty trash bin

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Part of https://github.com/owncloud/data_exporter/issues/211

## Motivation and Context
- there was no test coverage for testing of exporting with empty trash bin 

## How Has This Been Tested?
- locally
-  CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

