### PR TITLE
Do not throw an exception if there is no trashbin to import

### DIFF
--- a/lib/Importer/TrashBinImporter.php
+++ b/lib/Importer/TrashBinImporter.php
@@ -98,6 +98,15 @@ class TrashBinImporter {
 		$this->streamFile = $this
 			->streamHelper
 			->initStream($filename, 'rb');
+
+		if ($this->streamFile === false) {
+			// If the exported user had no trashbin at all,
+			// then there might be no trashbin to import,
+			// and not even an empty trashbin.jsonl
+			// In this case, just return.
+			return;
+		}
+
 		$this->currentLine = 1;
 
 		try {

--- a/lib/Utilities/StreamHelper.php
+++ b/lib/Utilities/StreamHelper.php
@@ -52,14 +52,14 @@ class StreamHelper {
 	}
 
 	/**
-	 * SetUp the Stream for the export
-	 * Create empty file and open stream
+	 * SetUp the Stream for the export or import
+	 * Create empty file if requested
 	 *
 	 * @param string $file
 	 * @param string $mode
 	 * @param bool $createFile
 	 *
-	 * @return resource
+	 * @return resource|false
 	 */
 	public function initStream($file, $mode, $createFile = false) {
 		if ($createFile) {
@@ -69,7 +69,7 @@ class StreamHelper {
 	}
 
 	/**
-	 * close the Stream for the export
+	 * close the Stream for the export or import
 	 *
 	 * @param resource $resource
 	 *
@@ -81,7 +81,6 @@ class StreamHelper {
 
 	/**
 	 * Write line to the Stream for the export
-	 * Create empty file and open stream
 	 *
 	 * @param resource $resource
 	 * @param Share | File $entity

--- a/tests/acceptance/features/cliDataExporter/import.feature
+++ b/tests/acceptance/features/cliDataExporter/import.feature
@@ -95,3 +95,10 @@ Feature: An administrator wants to import a user using the commandline
     And user "usertrash" should exist
     And as "usertrash" folder "AFolder" should exist
     And as "usertrash" file "AFolder/fileInFolder.txt" should exist
+
+  @issue-210
+  Scenario: importing without trash bin
+    When a user is imported from path "noTrashbinImport/testuser1" using the occ command
+    Then the command should have been successful
+    And user "testuser1" should exist
+    And as "testuser1" file "welcome.txt" should exist

--- a/tests/acceptance/features/cliDataExporter/importFileWithEmptyTrashBinDataExporterIssue210.feature
+++ b/tests/acceptance/features/cliDataExporter/importFileWithEmptyTrashBinDataExporterIssue210.feature
@@ -1,9 +1,0 @@
-@cli
-Feature: An administrator wants to import the files of his user using the commandline
-
-  @issue-210
-  Scenario: importing without trash bin
-    When a user is imported from path "noTrashbinImport/testuser1" using the occ command
-    Then the command should have failed with exit code 1
-    And the command output should contain the text "Import failed on %path% on line 2: Invalid Data." for path "noTrashbinImport/testuser1/trashbin.jsonl"
-    And user "testuser1" should exist


### PR DESCRIPTION
## Description
If there is no trashbin to import, then there might not even be a `trashbin.jsonl` to read.
If that happens, do not throw an exception, just quietly return - there is no need to crash out on a "null" trashbin.

## Related Issue
Fixes #210 

## How Has This Been Tested?
CI acceptance test scenario

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

