### PR TITLE
Update LastLoginTimestamp when importing for a new user

### DIFF
--- a/lib/Importer/MetadataImporter/UserImporter.php
+++ b/lib/Importer/MetadataImporter/UserImporter.php
@@ -117,6 +117,7 @@ class UserImporter {
 		$user->setDisplayName($userModel->getDisplayName());
 		$user->setEMailAddress($userModel->getEmail());
 		$user->setEnabled($userModel->isEnabled());
+		$user->updateLastLoginTimestamp();
 		$passwordHash = $userModel->getPasswordHash();
 
 		if ($passwordHash !== null && !empty(\trim($passwordHash))) {


### PR DESCRIPTION
## Description
Set the LastLoginTimestamp when a user is created for an import.
That prevents later code from executing "first time login" actions for the user when they next log in.
The importer already does the needed stuff to set up the user's file system etc. We don't want later code to do "bonus" stuff, like copying in the skeleton.

## Related Issue
Fixes #234 

## How Has This Been Tested?
Manually rerun the sequence in the issue and observe that the skeleton file has not been acccidentally added to the user's files.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
