### PR TITLE
fix: drop usage of ${}

### DIFF
--- a/lib/Extractor/FilesExtractor.php
+++ b/lib/Extractor/FilesExtractor.php
@@ -48,7 +48,7 @@ class FilesExtractor {
 			$nodePath = $node->getPath();
 			$relativeFileCachePath = $baseFolder->getRelativePath($nodePath);
 			// $relativeFileCachePath is expected to have a leading slash always
-			$path = Path::join("${exportPath}${relativeFileCachePath}");
+			$path = Path::join("$exportPath$relativeFileCachePath");
 
 			if ($node instanceof File) {
 				@\mkdir(\pathinfo($path, PATHINFO_DIRNAME), 0777, true);


### PR DESCRIPTION
## Description
In preparation of php8.2 support - see https://php.watch/versions/8.2/$%7Bvar%7D-string-interpolation-deprecated

Similar to core https://github.com/owncloud/core/pull/40995
